### PR TITLE
Define g:clors_name after hi clear

### DIFF
--- a/templates/mustaches/colorscheme.hbs
+++ b/templates/mustaches/colorscheme.hbs
@@ -7,12 +7,12 @@
 " Last Change: {{ date }}
 " ===============================================================
 
-let g:colors_name="{{ theme.name }}"
+set background={{ theme.background }}
 hi clear
 if exists("syntax_on")
   syntax reset
 endif
-set background={{ theme.background }}
+let g:colors_name="{{ theme.name }}"
 
 {{#each c~}}
   {{#if link}}hi link {{@key}} {{link~}}


### PR DESCRIPTION
It seems that calling `hi clear`, for some reason, undefines `g:colors_name`. I'm not sure if this is a bug in vim or actual expected behaviour. This can easily be fixed by changing the order of the statements. Actually the default vim color schemes use the same order.
