### PR TITLE
fix cannot allocate color

### DIFF
--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -7,9 +7,7 @@ const fs = require('fs')
 const installTemplates = require('./install-templates.js')
 const chalk = require('chalk')
 
-const blankterm = `color_foreground: ''
-color_background: ''
-color_0: ''
+const blankterm = `color_0: ''
 color_1: ''
 color_2: ''
 color_3: ''
@@ -25,6 +23,8 @@ color_12: ''
 color_13: ''
 color_14: ''
 color_15: ''
+color_foreground: ''
+color_background: ''
 `
 const defaultPalette = 'myblue: \'#99ccff\''
 
@@ -85,7 +85,7 @@ module.exports = function (projectPath, auto) {
   }
 }
 
-function createBoilerplate (projectPath, options) {
+function createBoilerplate(projectPath, options) {
   const addonsFolder = path.resolve(projectPath, 'estilo/addons')
   const termPath = path.resolve(addonsFolder, 'term.yml')
   let estiloStr = `name: '${options.name}'

--- a/templates/mustaches/colorscheme.hbs
+++ b/templates/mustaches/colorscheme.hbs
@@ -10,45 +10,45 @@
 set background={{ theme.background }}
 hi clear
 if exists("syntax_on")
-  syntax reset
+syntax reset
 endif
 let g:colors_name="{{ theme.name }}"
 
 
 let Italic = ""
 if exists('g:{{theme.name}}_italic')
-  let Italic = "italic"
+let Italic = "italic"
 endif
 let g:{{theme.name}}_italic = get(g:, '{{theme.name}}_italic', 0)
 
 let Bold = ""
 if exists('g:{{theme.name}}_bold')
-  let Bold = "bold"
+let Bold = "bold"
 endif
 
 let g:{{theme.name}}_bold = get(g:, '{{theme.name}}_bold', 0)
 {{#each c~}}
-  {{#if link}}hi link {{@key}} {{link~}}
-  {{~^~}}hi {{ @key }}
-    {{~#if fore}} guifg={{fore.[0]}} ctermfg={{fore.[1]}}{{/if}}
-    {{~#if back}} guibg={{back.[0]}} ctermbg={{back.[1]}}{{/if}}
-    {{~#if ui}} gui={{ui}} cterm={{ui}}{{/if}}
-    {{~#if guisp}} guisp={{guisp.[0]}}{{/if}}
-  {{~/if}}
+{{#if link}}hi link {{@key}} {{link~}}
+{{~^~}}hi {{ @key }}
+{{~#if fore}} guifg={{fore.[0]}} ctermfg={{fore.[1]}}{{/if}}
+{{~#if back}} guibg={{back.[0]}} ctermbg={{back.[1]}}{{/if}}
+{{~#if ui}} gui={{ui}} cterm={{ui}}{{/if}}
+{{~#if guisp}} guisp={{guisp.[0]}}{{/if}}
+{{~/if}}
 
 {{/each}}
 
 if exists('*term_setansicolors')
-  let g:terminal_ansi_colors = repeat([0], 16)
-
+let g:terminal_ansi_colors = [
 {{#each term}}
-  let g:terminal_ansi_colors[{{@key}}] = '{{this}}'
+\ '{{this}}',
 {{/each}}
+\ ]
 endif
 
 if has('nvim')
 {{#each term}}
-  let g:terminal_color_{{@key}} = '{{this}}'
+let g:terminal_color_{{@key}} = '{{this}}'
 {{/each}}
 endif
 

--- a/templates/mustaches/colorscheme.hbs
+++ b/templates/mustaches/colorscheme.hbs
@@ -40,9 +40,7 @@ let g:{{theme.name}}_bold = get(g:, '{{theme.name}}_bold', 0)
 
 if exists('*term_setansicolors')
 let g:terminal_ansi_colors = [
-{{#each term}}
-\ '{{this}}',
-{{/each}}
+\ {{#each term}}'{{this}}', {{/each}}
 \ ]
 endif
 


### PR DESCRIPTION
Hi @jacoborus,

I created a scheme using Estilo today and it was great. However, when I tried to load the theme in my `.vimrc`, I would continuously get an error:

```
Error detected while processing function <SNR>14_AddAnsiGroups:
line   18:
E254: Cannot allocate color 0
E254: Cannot allocate color 0
Press ENTER or type command to continue
```

I was trying several things to fix it, and occasionally it would also print `E121: Undefined variable: color_0` or `E121: Undefined variable: g:terminal_ansi_colors`.

I think I've fixed it, by slightly modifying the way the terminal colours are set. 

**Before:**

```
if exists('*term_setansicolors')
  let g:terminal_ansi_colors = repeat([0], 16)

  let g:terminal_ansi_colors[color_0] = '#403f53'
  let g:terminal_ansi_colors[color_1] = '#288ed7'
  let g:terminal_ansi_colors[color_2] = '#2AA298'
  let g:terminal_ansi_colors[color_3] = '#08916a'
  let g:terminal_ansi_colors[color_4] = '#d6438a'
  let g:terminal_ansi_colors[color_5] = '#de3d3b'
  let g:terminal_ansi_colors[color_6] = '#F0F0F0'
  let g:terminal_ansi_colors[color_7] = '#E0AF02'
  let g:terminal_ansi_colors[color_8] = '#403f53'
  let g:terminal_ansi_colors[color_9] = '#FF0000'
  let g:terminal_ansi_colors[color_10] = '#00FF00'
  let g:terminal_ansi_colors[color_11] = '#de3d3b'
  let g:terminal_ansi_colors[color_12] = '#0000FF'
  let g:terminal_ansi_colors[color_13] = '#FF0000'
  let g:terminal_ansi_colors[color_14] = '#0000FF'
  let g:terminal_ansi_colors[color_15] = '#FFFFFF'
endif
```

**After:**

```
if exists('*term_setansicolors')
let g:terminal_ansi_colors = [
\ '#403f53', '#288ed7', '#2AA298', '#08916a', '#d6438a', '#de3d3b', '#F0F0F0', '#E0AF02', '#403f53', '#FF0000', '#00FF00', '#de3d3b', '#0000FF', '#FF0000', '#0000FF', '#FFFFFF', 
\ ]
endif
```

This has fixed the error for me, although I realize now the keys of the colours are not being used, which means the colours in `term.yml` should be in ANSI order (which is why I updated `init.js` to put them at the end). I'm new to Vim/Estilo, so please let me know your thoughts.

I'm using Vim 8.2.750 on macOS 10.15.4.