### PR TITLE
Update dnt to solve library resolution issue

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,5 +7,8 @@
     "install": "deno task bundle-assets && deno install --allow-read --allow-write estilo.ts",
     "build-npm": "deno run -A scripts/build_npm.ts",
     "create-binaries": "deno run -A scripts/create_binaries.ts"
+  },
+  "imports": {
+    "@deno/dnt": "jsr:@deno/dnt@^0.41.3"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,27 +2,49 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@david/code-block-writer@^13.0.2": "jsr:@david/code-block-writer@13.0.2",
       "jsr:@david/dax": "jsr:@david/dax@0.39.2",
       "jsr:@david/which@0.3": "jsr:@david/which@0.3.0",
+      "jsr:@deno/cache-dir@^0.10.3": "jsr:@deno/cache-dir@0.10.3",
+      "jsr:@deno/dnt@^0.41.3": "jsr:@deno/dnt@0.41.3",
       "jsr:@jacoborus/hexterm": "jsr:@jacoborus/hexterm@2.1.0",
       "jsr:@jacoborus/hexterm@2.1.1": "jsr:@jacoborus/hexterm@2.1.1",
       "jsr:@std/assert@^0.213.0": "jsr:@std/assert@0.213.1",
       "jsr:@std/assert@^0.219.1": "jsr:@std/assert@0.219.1",
+      "jsr:@std/assert@^0.223.0": "jsr:@std/assert@0.223.0",
+      "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
       "jsr:@std/bytes@^0.213.0": "jsr:@std/bytes@0.213.1",
+      "jsr:@std/bytes@^0.223.0": "jsr:@std/bytes@0.223.0",
       "jsr:@std/fmt@0.213.0": "jsr:@std/fmt@0.213.0",
+      "jsr:@std/fmt@1": "jsr:@std/fmt@1.0.0",
+      "jsr:@std/fmt@^0.223": "jsr:@std/fmt@0.223.0",
       "jsr:@std/fs@0.213.0": "jsr:@std/fs@0.213.0",
       "jsr:@std/fs@0.219.1": "jsr:@std/fs@0.219.1",
+      "jsr:@std/fs@1": "jsr:@std/fs@1.0.1",
+      "jsr:@std/fs@^0.223": "jsr:@std/fs@0.223.0",
+      "jsr:@std/fs@^0.229.3": "jsr:@std/fs@0.229.3",
       "jsr:@std/io@0.213.0": "jsr:@std/io@0.213.0",
       "jsr:@std/io@^0.213.0": "jsr:@std/io@0.213.0",
+      "jsr:@std/io@^0.223": "jsr:@std/io@0.223.0",
       "jsr:@std/path@0.213.0": "jsr:@std/path@0.213.0",
       "jsr:@std/path@0.219.1": "jsr:@std/path@0.219.1",
+      "jsr:@std/path@1": "jsr:@std/path@1.0.2",
+      "jsr:@std/path@1.0.0-rc.1": "jsr:@std/path@1.0.0-rc.1",
       "jsr:@std/path@^0.213.0": "jsr:@std/path@0.213.0",
       "jsr:@std/path@^0.219.1": "jsr:@std/path@0.219.1",
+      "jsr:@std/path@^0.223": "jsr:@std/path@0.223.0",
+      "jsr:@std/path@^0.225.2": "jsr:@std/path@0.225.2",
+      "jsr:@std/path@^1.0.2": "jsr:@std/path@1.0.2",
       "jsr:@std/streams@0.213.0": "jsr:@std/streams@0.213.0",
       "jsr:@std/yaml@0.219.1": "jsr:@std/yaml@0.219.1",
+      "jsr:@ts-morph/bootstrap@^0.24.0": "jsr:@ts-morph/bootstrap@0.24.0",
+      "jsr:@ts-morph/common@^0.24.0": "jsr:@ts-morph/common@0.24.0",
       "npm:eta@1.14.2": "npm:eta@1.14.2"
     },
     "jsr": {
+      "@david/code-block-writer@13.0.2": {
+        "integrity": "14dd3baaafa3a2dea8bf7dfbcddeccaa13e583da2d21d666c01dc6d681cd74ad"
+      },
       "@david/dax@0.39.2": {
         "integrity": "f7fde219e9a4b331024bcc89bfc5c63b85348cad61ff26a963d893262d92b01c",
         "dependencies": [
@@ -37,6 +59,26 @@
       "@david/which@0.3.0": {
         "integrity": "6bdb62c40ac90edcf328e854fa8103a8db21e7c326089cbe3c3a1cf7887d3204"
       },
+      "@deno/cache-dir@0.10.3": {
+        "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
+        "dependencies": [
+          "jsr:@std/fmt@^0.223",
+          "jsr:@std/fs@^0.223",
+          "jsr:@std/io@^0.223",
+          "jsr:@std/path@^0.223"
+        ]
+      },
+      "@deno/dnt@0.41.3": {
+        "integrity": "b2ef2c8a5111eef86cb5bfcae103d6a2938e8e649e2461634a7befb7fc59d6d2",
+        "dependencies": [
+          "jsr:@david/code-block-writer@^13.0.2",
+          "jsr:@deno/cache-dir@^0.10.3",
+          "jsr:@std/fmt@1",
+          "jsr:@std/fs@1",
+          "jsr:@std/path@1",
+          "jsr:@ts-morph/bootstrap@^0.24.0"
+        ]
+      },
       "@jacoborus/hexterm@2.1.0": {
         "integrity": "2b57c9a9e05f497ec50d01bad54807249e51b7956803b11c9e528675ea5b33c3"
       },
@@ -49,11 +91,26 @@
       "@std/assert@0.219.1": {
         "integrity": "e76c2a1799a78f0f4db7de04bdc9b908a7a4b821bb65eda0285885297d4fb8af"
       },
+      "@std/assert@0.223.0": {
+        "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
+      },
+      "@std/assert@0.226.0": {
+        "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3"
+      },
       "@std/bytes@0.213.1": {
         "integrity": "97f133c5bfb18b4522675e0822089de91e32618a4d8c2fcea8e175aca8f1f65c"
       },
+      "@std/bytes@0.223.0": {
+        "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
+      },
       "@std/fmt@0.213.0": {
         "integrity": "4623054b309ee60e37cc3db2bc55385aa129bb899f0c50e912d79a763aee6b6a"
+      },
+      "@std/fmt@0.223.0": {
+        "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
+      },
+      "@std/fmt@1.0.0": {
+        "integrity": "8a95c9fdbb61559418ccbc0f536080cf43341655e1444f9d375a66886ceaaa3d"
       },
       "@std/fs@0.213.0": {
         "integrity": "607ed7611e61e33179e2a6a7c60c086d6fef3b79438c403c51a336d0ca4e162d",
@@ -69,11 +126,33 @@
           "jsr:@std/path@^0.219.1"
         ]
       },
+      "@std/fs@0.223.0": {
+        "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
+      },
+      "@std/fs@0.229.3": {
+        "integrity": "783bca21f24da92e04c3893c9e79653227ab016c48e96b3078377ebd5222e6eb",
+        "dependencies": [
+          "jsr:@std/path@1.0.0-rc.1"
+        ]
+      },
+      "@std/fs@1.0.1": {
+        "integrity": "d6914ca2c21abe591f733b31dbe6331e446815e513e2451b3b9e472daddfefcb",
+        "dependencies": [
+          "jsr:@std/path@^1.0.2"
+        ]
+      },
       "@std/io@0.213.0": {
         "integrity": "e78db92000e718c4b37e3c5f8a854a7c8d66cf4f1ab81d2c5c834172e66191cb",
         "dependencies": [
           "jsr:@std/assert@^0.213.0",
           "jsr:@std/bytes@^0.213.0"
+        ]
+      },
+      "@std/io@0.223.0": {
+        "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
+        "dependencies": [
+          "jsr:@std/assert@^0.223.0",
+          "jsr:@std/bytes@^0.223.0"
         ]
       },
       "@std/path@0.213.0": {
@@ -88,6 +167,24 @@
           "jsr:@std/assert@^0.219.1"
         ]
       },
+      "@std/path@0.223.0": {
+        "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
+        "dependencies": [
+          "jsr:@std/assert@^0.223.0"
+        ]
+      },
+      "@std/path@0.225.2": {
+        "integrity": "0f2db41d36b50ef048dcb0399aac720a5348638dd3cb5bf80685bf2a745aa506",
+        "dependencies": [
+          "jsr:@std/assert@^0.226.0"
+        ]
+      },
+      "@std/path@1.0.0-rc.1": {
+        "integrity": "b8c00ae2f19106a6bb7cbf1ab9be52aa70de1605daeb2dbdc4f87a7cbaf10ff6"
+      },
+      "@std/path@1.0.2": {
+        "integrity": "a452174603f8c620bd278a380c596437a9eef50c891c64b85812f735245d9ec7"
+      },
       "@std/streams@0.213.0": {
         "integrity": "14519c7ce5f4c88de2e365f4bf1b8371c942a9fe0e1f9a0b9e10a56e3c3e3877",
         "dependencies": [
@@ -96,6 +193,19 @@
       },
       "@std/yaml@0.219.1": {
         "integrity": "62c99e2f3f006bbbd5d3d909f7bc148190a5411849d6e5dc7a8608960457b1df"
+      },
+      "@ts-morph/bootstrap@0.24.0": {
+        "integrity": "a826a2ef7fa8a7c3f1042df2c034d20744d94da2ee32bf29275bcd4dffd3c060",
+        "dependencies": [
+          "jsr:@ts-morph/common@^0.24.0"
+        ]
+      },
+      "@ts-morph/common@0.24.0": {
+        "integrity": "12b625b8e562446ba658cdbe9ad77774b4bd96b992ae8bd34c60dbf24d06c1f3",
+        "dependencies": [
+          "jsr:@std/fs@^0.229.3",
+          "jsr:@std/path@^0.225.2"
+        ]
       }
     },
     "npm": {
@@ -439,5 +549,10 @@
     "https://deno.land/x/ts_morph@20.0.0/common/typescript.js": "b9edf0a451685d13e0467a7ed4351d112b74bd1e256b915a2b941054e31c1736",
     "https://deno.land/x/wasmbuild@0.15.1/cache.ts": "9d01b5cb24e7f2a942bbd8d14b093751fa690a6cde8e21709ddc97667e6669ed",
     "https://deno.land/x/wasmbuild@0.15.1/loader.ts": "8c2fc10e21678e42f84c5135d8ab6ab7dc92424c3f05d2354896a29ccfd02a63"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@deno/dnt@^0.41.3"
+    ]
   }
 }

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.40.0/mod.ts";
+import { build, emptyDir } from "@deno/dnt";
 import denojson from "../deno.json" with { type: "json" };
 
 const version = denojson.version;


### PR DESCRIPTION
Current version was causing this error:
```
Download https://registry-staging.deno.com/@std/path/meta.json
WARN Failed fetching https://registry-staging.deno.com/@std/path/meta.json. Retrying in 250ms...
WARN Failed fetching https://registry-staging.deno.com/@std/path/meta.json. Retrying in 500ms...
WARN Failed fetching https://registry-staging.deno.com/@std/path/meta.json. Retrying in 1000ms...
panicked at wasm\src\lib.rs:24:1:
unexpected exception: JsValue(TypeError: client error (Connect)
TypeError: client error (Connect)
    at async mainFetch (ext:deno_fetch/26_fetch.js:170:12)
    at async fetch (ext:deno_fetch/26_fetch.js:391:7)
    at async fetchWithRetries (https://deno.land/x/deno_cache@0.6.2/file_fetcher.ts:280:19)
    at async FileFetcher.#fetchRemote (https://deno.land/x/deno_cache@0.6.2/file_fetcher.ts:209:22)
    at async FileFetcher.fetch (https://deno.land/x/deno_cache@0.6.2/file_fetcher.ts:261:24))
```

See:
- https://github.com/denoland/dnt/issues/378
- https://github.com/denoland/dnt/releases/tag/0.41.0